### PR TITLE
feat: Issue #5 - X / illusupi 関連メトリクスの追加と初期データ投入

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import { ClientInit } from '../components/ClientInit';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -17,6 +18,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={inter.className}>
+        <ClientInit />
         <div className="min-h-screen bg-gray-50">
           <header className="bg-white shadow-sm">
             <div className="max-w-7xl mx-auto px-4 py-4 sm:px-6 lg:px-8">

--- a/src/app/test-db/page.tsx
+++ b/src/app/test-db/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getAllMetrics, addMetric } from '../../lib/metrics';
+import { addDataPoint, getDataPointsByMetric } from '../../lib/data';
+import { getToday } from '../../lib/utils';
+import { Metric } from '../../types/metric';
+import { DataPoint } from '../../types/data';
+
+export default function TestDBPage() {
+  const [metrics, setMetrics] = useState<Metric[]>([]);
+  const [dataPoints, setDataPoints] = useState<DataPoint[]>([]);
+  const [status, setStatus] = useState<string>('');
+
+  useEffect(() => {
+    loadMetrics();
+  }, []);
+
+  async function loadMetrics() {
+    try {
+      const data = await getAllMetrics();
+      setMetrics(data);
+      setStatus(`メトリクスを ${data.length} 件読み込みました`);
+    } catch (error) {
+      setStatus(`エラー: ${error}`);
+    }
+  }
+
+  async function loadDataPoints(metricId: string) {
+    try {
+      const data = await getDataPointsByMetric(metricId);
+      setDataPoints(data);
+      setStatus(`データポイントを ${data.length} 件読み込みました`);
+    } catch (error) {
+      setStatus(`エラー: ${error}`);
+    }
+  }
+
+  async function addTestDataPoint() {
+    try {
+      if (metrics.length === 0) {
+        setStatus('メトリクスがありません');
+        return;
+      }
+
+      const metricId = metrics[0].id;
+      const date = getToday();
+      const value = Math.random() * 100;
+
+      await addDataPoint(metricId, date, value, 'テストデータ');
+      setStatus(`データポイントを追加しました: ${value.toFixed(2)}`);
+
+      await loadDataPoints(metricId);
+    } catch (error) {
+      setStatus(`エラー: ${error}`);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">
+          データベーステスト
+        </h2>
+        <p className="text-sm text-gray-600 mb-4">
+          Status: {status}
+        </p>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h3 className="text-lg font-semibold mb-2">メトリクス一覧</h3>
+        <ul className="space-y-2">
+          {metrics.map(metric => (
+            <li
+              key={metric.id}
+              className="p-2 border rounded hover:bg-gray-50 cursor-pointer"
+              onClick={() => loadDataPoints(metric.id)}
+            >
+              {metric.name} ({metric.unit})
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h3 className="text-lg font-semibold mb-2">データポイント</h3>
+        <button
+          onClick={addTestDataPoint}
+          className="mb-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          テストデータを追加
+        </button>
+        <ul className="space-y-1 text-sm">
+          {dataPoints.map(dp => (
+            <li key={dp.id} className="p-1 border-b">
+              {dp.date}: {dp.value} ({dp.note})
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/test-db/page.tsx
+++ b/src/app/test-db/page.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { getAllMetrics, addMetric } from '../../lib/metrics';
-import { addDataPoint, getDataPointsByMetric } from '../../lib/data';
+import { addDataPoint, getDataPointsByMetric, clearAllDataPoints } from '../../lib/data';
 import { getToday } from '../../lib/utils';
 import { Metric } from '../../types/metric';
 import { DataPoint } from '../../types/data';
+import { seedInitialData } from '../../lib/seed-data';
 
 export default function TestDBPage() {
   const [metrics, setMetrics] = useState<Metric[]>([]);
@@ -56,6 +57,26 @@ export default function TestDBPage() {
     }
   }
 
+  async function handleSeedData() {
+    try {
+      await seedInitialData();
+      setStatus('初期データを投入しました（2024-11-12）');
+      await loadMetrics();
+    } catch (error) {
+      setStatus(`エラー: ${error}`);
+    }
+  }
+
+  async function handleClearData() {
+    try {
+      await clearAllDataPoints();
+      setStatus('すべてのデータポイントを削除しました');
+      setDataPoints([]);
+    } catch (error) {
+      setStatus(`エラー: ${error}`);
+    }
+  }
+
   return (
     <div className="space-y-6">
       <div>
@@ -65,6 +86,24 @@ export default function TestDBPage() {
         <p className="text-sm text-gray-600 mb-4">
           Status: {status}
         </p>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h3 className="text-lg font-semibold mb-2">データ操作</h3>
+        <div className="flex gap-2">
+          <button
+            onClick={handleSeedData}
+            className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+          >
+            初期データを投入（2024-11-12）
+          </button>
+          <button
+            onClick={handleClearData}
+            className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+          >
+            全データをクリア
+          </button>
+        </div>
       </div>
 
       <div className="bg-white p-4 rounded-lg shadow">

--- a/src/components/ClientInit.tsx
+++ b/src/components/ClientInit.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+import { initializeDefaultMetrics } from '../lib/metrics';
+
+/**
+ * クライアント側で実行される初期化コンポーネント
+ * デフォルトメトリクスの初期化を行う
+ */
+export function ClientInit() {
+  useEffect(() => {
+    // アプリケーション起動時にデフォルトメトリクスを初期化
+    initializeDefaultMetrics().catch(console.error);
+  }, []);
+
+  return null;
+}

--- a/src/config/default-metrics.json
+++ b/src/config/default-metrics.json
@@ -32,5 +32,71 @@
     "max": 12,
     "order": 3,
     "active": true
+  },
+  {
+    "id": "x-follow",
+    "name": "X フォロー数",
+    "description": "X（Twitter）でフォローしている人数",
+    "unit": "人",
+    "type": "count",
+    "color": "#1DA1F2",
+    "min": 0,
+    "order": 4,
+    "active": true
+  },
+  {
+    "id": "x-follower",
+    "name": "X フォロワー数",
+    "description": "X（Twitter）のフォロワー人数",
+    "unit": "人",
+    "type": "count",
+    "color": "#14171A",
+    "min": 0,
+    "order": 5,
+    "active": true
+  },
+  {
+    "id": "x-total-posts",
+    "name": "X 累計ポスト数",
+    "description": "X（Twitter）の累計投稿数",
+    "unit": "件",
+    "type": "count",
+    "color": "#657786",
+    "min": 0,
+    "order": 6,
+    "active": true
+  },
+  {
+    "id": "x-sent-dms",
+    "name": "X 送信DM数",
+    "description": "X（Twitter）で送信したDMの数",
+    "unit": "件",
+    "type": "count",
+    "color": "#AAB8C2",
+    "min": 0,
+    "order": 7,
+    "active": true
+  },
+  {
+    "id": "illusupi-users",
+    "name": "illusupi ユーザー数",
+    "description": "illusupi の登録ユーザー数",
+    "unit": "人",
+    "type": "count",
+    "color": "#F59E0B",
+    "min": 0,
+    "order": 8,
+    "active": true
+  },
+  {
+    "id": "illusupi-posts",
+    "name": "illusupi 関連投稿数",
+    "description": "illusupi に関する投稿・言及の数",
+    "unit": "件",
+    "type": "count",
+    "color": "#8B5CF6",
+    "min": 0,
+    "order": 9,
+    "active": true
   }
 ]

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -124,3 +124,11 @@ export async function getRecentDataPoints(
 
   return await getDataPointsByMetric(metricId, startDate, endDate);
 }
+
+/**
+ * すべてのデータポイントを削除（テスト用）
+ */
+export async function clearAllDataPoints(): Promise<void> {
+  await db.dataPoints.clear();
+  console.log('すべてのデータポイントを削除しました');
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,0 +1,126 @@
+import { db } from './db';
+import { DataPoint } from '../types/data';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * データポイントを追加
+ */
+export async function addDataPoint(
+  metricId: string,
+  date: string,
+  value: number,
+  note?: string
+): Promise<string> {
+  const now = new Date().toISOString();
+
+  const dataPoint: DataPoint = {
+    id: uuidv4(),
+    metricId,
+    date,
+    value,
+    note,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  return await db.dataPoints.add(dataPoint);
+}
+
+/**
+ * データポイントを更新
+ */
+export async function updateDataPoint(
+  id: string,
+  changes: Partial<Omit<DataPoint, 'id' | 'metricId' | 'createdAt'>>
+): Promise<number> {
+  const now = new Date().toISOString();
+  return await db.dataPoints.update(id, {
+    ...changes,
+    updatedAt: now,
+  });
+}
+
+/**
+ * データポイントを削除
+ */
+export async function deleteDataPoint(id: string): Promise<void> {
+  await db.dataPoints.delete(id);
+}
+
+/**
+ * 特定のメトリクスのデータポイントを取得（日付範囲指定）
+ */
+export async function getDataPointsByMetric(
+  metricId: string,
+  startDate?: string,
+  endDate?: string
+): Promise<DataPoint[]> {
+  let query = db.dataPoints.where({ metricId });
+
+  if (startDate && endDate) {
+    query = query.and(dp => dp.date >= startDate && dp.date <= endDate);
+  } else if (startDate) {
+    query = query.and(dp => dp.date >= startDate);
+  } else if (endDate) {
+    query = query.and(dp => dp.date <= endDate);
+  }
+
+  return await query.sortBy('date');
+}
+
+/**
+ * 特定の日付のデータポイントを取得
+ */
+export async function getDataPointsByDate(date: string): Promise<DataPoint[]> {
+  return await db.dataPoints.where({ date }).toArray();
+}
+
+/**
+ * 特定のメトリクス + 日付のデータポイントを取得
+ */
+export async function getDataPoint(
+  metricId: string,
+  date: string
+): Promise<DataPoint | undefined> {
+  return await db.dataPoints
+    .where('[metricId+date]')
+    .equals([metricId, date])
+    .first();
+}
+
+/**
+ * 複数のデータポイントを一括追加/更新
+ */
+export async function upsertDataPoints(
+  date: string,
+  data: Record<string, number>
+): Promise<void> {
+  const now = new Date().toISOString();
+
+  await db.transaction('rw', db.dataPoints, async () => {
+    for (const [metricId, value] of Object.entries(data)) {
+      const existing = await getDataPoint(metricId, date);
+
+      if (existing) {
+        await updateDataPoint(existing.id, { value, updatedAt: now });
+      } else {
+        await addDataPoint(metricId, date, value);
+      }
+    }
+  });
+}
+
+/**
+ * 過去 N 日間のデータポイントを取得
+ */
+export async function getRecentDataPoints(
+  metricId: string,
+  days: number
+): Promise<DataPoint[]> {
+  const endDate = new Date().toISOString().split('T')[0];
+  const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0];
+
+  return await getDataPointsByMetric(metricId, startDate, endDate);
+}

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,71 @@
+import { db } from './db';
+import { Metric } from '../types/metric';
+import defaultMetrics from '../config/default-metrics.json';
+
+/**
+ * デフォルトメトリクスを初期化
+ * 初回起動時のみ実行
+ */
+export async function initializeDefaultMetrics(): Promise<void> {
+  const count = await db.metrics.count();
+
+  if (count === 0) {
+    await db.metrics.bulkAdd(defaultMetrics as Metric[]);
+    console.log('デフォルトメトリクスを初期化しました');
+  }
+}
+
+/**
+ * すべてのメトリクスを取得（order でソート）
+ */
+export async function getAllMetrics(): Promise<Metric[]> {
+  return await db.metrics.orderBy('order').toArray();
+}
+
+/**
+ * アクティブなメトリクスのみ取得
+ */
+export async function getActiveMetrics(): Promise<Metric[]> {
+  return await db.metrics
+    .filter(metric => metric.active)
+    .sortBy('order');
+}
+
+/**
+ * ID でメトリクスを取得
+ */
+export async function getMetricById(id: string): Promise<Metric | undefined> {
+  return await db.metrics.get(id);
+}
+
+/**
+ * メトリクスを追加
+ */
+export async function addMetric(metric: Metric): Promise<string> {
+  return await db.metrics.add(metric);
+}
+
+/**
+ * メトリクスを更新
+ */
+export async function updateMetric(id: string, changes: Partial<Metric>): Promise<number> {
+  return await db.metrics.update(id, changes);
+}
+
+/**
+ * メトリクスを削除
+ */
+export async function deleteMetric(id: string): Promise<void> {
+  await db.metrics.delete(id);
+}
+
+/**
+ * メトリクスの表示順を更新
+ */
+export async function updateMetricsOrder(metrics: Metric[]): Promise<void> {
+  await db.transaction('rw', db.metrics, async () => {
+    for (const metric of metrics) {
+      await db.metrics.update(metric.id, { order: metric.order });
+    }
+  });
+}

--- a/src/lib/seed-data.ts
+++ b/src/lib/seed-data.ts
@@ -1,0 +1,31 @@
+import { addDataPoint } from './data';
+
+/**
+ * 初期データを投入
+ * 2024-11-12 のデータ
+ */
+export async function seedInitialData(): Promise<void> {
+  const date = '2024-11-12';
+
+  const initialData = [
+    { metricId: 'x-follow', value: 43, note: '初期データ' },
+    { metricId: 'x-follower', value: 1, note: '初期データ' },
+    { metricId: 'x-total-posts', value: 2, note: '初期データ' },
+    { metricId: 'x-sent-dms', value: 0, note: '初期データ' },
+    { metricId: 'illusupi-users', value: 0, note: '初期データ' },
+    { metricId: 'illusupi-posts', value: 0, note: '初期データ' },
+  ];
+
+  console.log('初期データを投入中...');
+
+  for (const data of initialData) {
+    try {
+      await addDataPoint(data.metricId, date, data.value, data.note);
+      console.log(`✓ ${data.metricId}: ${data.value}`);
+    } catch (error) {
+      console.error(`✗ ${data.metricId} の投入に失敗:`, error);
+    }
+  }
+
+  console.log('初期データ投入完了');
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,37 @@
+/**
+ * 日付を YYYY-MM-DD 形式にフォーマット
+ */
+export function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+/**
+ * 今日の日付を YYYY-MM-DD 形式で取得
+ */
+export function getToday(): string {
+  return formatDate(new Date());
+}
+
+/**
+ * N 日前の日付を取得
+ */
+export function getDaysAgo(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return formatDate(date);
+}
+
+/**
+ * 日付範囲の配列を生成
+ */
+export function getDateRange(startDate: string, endDate: string): string[] {
+  const dates: string[] = [];
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    dates.push(formatDate(new Date(d)));
+  }
+
+  return dates;
+}


### PR DESCRIPTION
## 概要

Issue #5 の実装が完了しました。X（Twitter）と illusupi 関連の6つのメトリクスを追加し、初期データ（2024-11-12）を投入する機能を実装しました。

## 実装内容

### 1. デフォルトメトリクスの追加 (default-metrics.json)
- ✅ X フォロー数 (x-follow)
- ✅ X フォロワー数 (x-follower)
- ✅ X 累計ポスト数 (x-total-posts)
- ✅ X 送信DM数 (x-sent-dms)
- ✅ illusupi ユーザー数 (illusupi-users)
- ✅ illusupi 関連投稿数 (illusupi-posts)

### 2. 初期データ投入機能 (lib/seed-data.ts)
- ✅ `seedInitialData()` 関数を実装
- ✅ 2024-11-12 のデータを投入
  - x-follow: 43
  - x-follower: 1
  - x-total-posts: 2
  - x-sent-dms: 0
  - illusupi-users: 0
  - illusupi-posts: 0

### 3. テストページの機能追加 (app/test-db/page.tsx)
- ✅ 初期データを投入ボタンを追加
- ✅ 全データをクリアボタンを追加
- ✅ データ操作セクションを追加

### 4. データ管理機能の追加 (lib/data.ts)
- ✅ `clearAllDataPoints()` 関数を実装（テスト用）

## 受け入れ基準

- ✅ default-metrics.json に6つのメトリクスが追加されている
- ✅ メトリクスの定義が正しい（ID、名前、単位、タイプ、カラー）
- ✅ 初期データ投入スクリプトが動作する
- ✅ テストページで「初期データを投入」ボタンが動作する
- ✅ 投入後、メトリクス一覧に新しいメトリクスが表示される
- ✅ 各メトリクスをクリックすると、2024-11-12 のデータが表示される
- ✅ データが IndexedDB に永続化される
- ✅ TypeScript のビルドエラーがない

## テスト手順

1. `pnpm install` で依存関係をインストール
2. `pnpm dev` でアプリケーションを起動
3. http://localhost:3000/test-db にアクセス
4. 「初期データを投入（2024-11-12）」ボタンをクリック
5. メトリクス一覧に9個のメトリクスが表示されることを確認
6. 各メトリクス（x-follow、x-follower等）をクリック
7. 2024-11-12 のデータが正しく表示されることを確認
8. ブラウザをリロードしてもデータが保持されることを確認

## ビルド結果

```
✓ Compiled successfully
✓ Generating static pages (6/6)
✓ No TypeScript errors
```

## 技術スタック

- TypeScript
- Dexie.js (IndexedDB)
- JSON（メトリクス設定）

## 次のステップ

Issue #5 が完了したので、Phase 3（入力 UI）の実装に進むことができます。

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)