### PR TITLE
feat: Phase 4 & 6 - ダッシュボード UI + データエクスポート (#9, #11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+trees/

--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -1,12 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { exportToJSON, exportToCSV, downloadFile } from '@/lib/export';
+
 export default function ConfigPage() {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExportJSON = async () => {
+    try {
+      setIsExporting(true);
+      const content = await exportToJSON();
+      const filename = `metrics-export-${new Date().toISOString().split('T')[0]}.json`;
+      downloadFile(content, filename, 'application/json');
+    } catch (error) {
+      console.error('JSON エクスポートエラー:', error);
+      alert('JSON エクスポート中にエラーが発生しました');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleExportCSV = async () => {
+    try {
+      setIsExporting(true);
+      const content = await exportToCSV();
+      const filename = `metrics-export-${new Date().toISOString().split('T')[0]}.csv`;
+      downloadFile(content, filename, 'text/csv');
+    } catch (error) {
+      console.error('CSV エクスポートエラー:', error);
+      alert('CSV エクスポート中にエラーが発生しました');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold text-gray-800">
         メトリクス設定
       </h2>
-      <p className="text-gray-600">
-        設定画面（Phase 6 で実装予定）
-      </p>
+
+      {/* データエクスポートセクション */}
+      <div className="bg-white p-6 rounded-lg shadow">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">
+          データエクスポート
+        </h3>
+        <p className="text-gray-600 mb-4">
+          メトリクスデータを JSON または CSV 形式でエクスポートできます。
+        </p>
+        <div className="flex gap-4">
+          <button
+            onClick={handleExportJSON}
+            disabled={isExporting}
+            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isExporting ? 'エクスポート中...' : 'JSON でエクスポート'}
+          </button>
+          <button
+            onClick={handleExportCSV}
+            disabled={isExporting}
+            className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isExporting ? 'エクスポート中...' : 'CSV でエクスポート'}
+          </button>
+        </div>
+      </div>
+
+      {/* 今後の設定機能用プレースホルダー */}
+      <div className="bg-white p-6 rounded-lg shadow">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">
+          その他の設定
+        </h3>
+        <p className="text-gray-600">
+          メトリクスの追加・編集・削除機能は今後実装予定です。
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,155 @@
-export default function Home() {
+'use client';
+
+import { useEffect, useState } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { getAllMetrics } from '@/lib/metrics';
+import { getAllDataPoints } from '@/lib/data';
+import { Metric } from '@/types/metric';
+import { DataPoint } from '@/types/data';
+
+interface ChartDataPoint {
+  date: string;
+  displayDate: string;
+  value: number;
+}
+
+export default function DashboardPage() {
+  const [metrics, setMetrics] = useState<Metric[]>([]);
+  const [dataPoints, setDataPoints] = useState<DataPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // データ読み込み
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const [metricsData, dataPointsData] = await Promise.all([
+          getAllMetrics(),
+          getAllDataPoints()
+        ]);
+
+        // アクティブなメトリクスのみをorderでソート
+        setMetrics(metricsData.filter(m => m.active).sort((a, b) => a.order - b.order));
+        setDataPoints(dataPointsData);
+      } catch (error) {
+        console.error('データの読み込みに失敗しました:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadData();
+  }, []);
+
+  // 日付フォーマット: YYYY-MM-DD → MM/DD
+  const formatDate = (dateString: string): string => {
+    const [, month, day] = dateString.split('-');
+    return `${month}/${day}`;
+  };
+
+  // メトリクスごとのグラフデータを生成
+  const getChartData = (metricId: string): ChartDataPoint[] => {
+    const metricData = dataPoints
+      .filter(dp => dp.metricId === metricId)
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .map(dp => ({
+        date: dp.date,
+        displayDate: formatDate(dp.date),
+        value: dp.value
+      }));
+
+    return metricData;
+  };
+
+  if (loading) {
+    return (
+      <div className="p-4 md:p-8">
+        <h1 className="text-2xl font-bold mb-6">ダッシュボード</h1>
+        <p className="text-gray-600">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (metrics.length === 0) {
+    return (
+      <div className="p-4 md:p-8">
+        <h1 className="text-2xl font-bold mb-6">ダッシュボード</h1>
+        <p className="text-gray-600">
+          メトリクスがありません。設定ページからメトリクスを有効化してください。
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-semibold text-gray-800">
-        Dashboard
-      </h2>
-      <p className="text-gray-600">
-        メトリクスダッシュボード（Phase 4 で実装予定）
-      </p>
+    <div className="p-4 md:p-8">
+      <h1 className="text-2xl font-bold mb-6 text-gray-800">ダッシュボード</h1>
+
+      <div className="space-y-8">
+        {metrics.map(metric => {
+          const chartData = getChartData(metric.id);
+
+          return (
+            <div key={metric.id} className="bg-white p-4 md:p-6 rounded-lg shadow">
+              <div className="mb-4">
+                <h2 className="text-lg font-semibold text-gray-800">
+                  {metric.name}
+                  {metric.unit && <span className="text-sm text-gray-500 ml-2">({metric.unit})</span>}
+                </h2>
+                {metric.description && (
+                  <p className="text-sm text-gray-600 mt-1">{metric.description}</p>
+                )}
+              </div>
+
+              {chartData.length === 0 ? (
+                <div className="h-[300px] flex items-center justify-center text-gray-500">
+                  データがありません
+                </div>
+              ) : (
+                <ResponsiveContainer width="100%" height={300}>
+                  <LineChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <XAxis
+                      dataKey="displayDate"
+                      tick={{ fill: '#6b7280', fontSize: 12 }}
+                      tickLine={{ stroke: '#9ca3af' }}
+                    />
+                    <YAxis
+                      tick={{ fill: '#6b7280', fontSize: 12 }}
+                      tickLine={{ stroke: '#9ca3af' }}
+                      domain={[
+                        metric.min !== undefined ? metric.min : 'auto',
+                        metric.max !== undefined ? metric.max : 'auto'
+                      ]}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: '#fff',
+                        border: '1px solid #e5e7eb',
+                        borderRadius: '0.375rem',
+                        boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)'
+                      }}
+                      labelStyle={{ color: '#374151', fontWeight: 600 }}
+                    />
+                    <Legend
+                      wrapperStyle={{ paddingTop: '1rem' }}
+                      iconType="line"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="value"
+                      stroke={metric.color}
+                      strokeWidth={2}
+                      name={metric.name}
+                      dot={{ fill: metric.color, r: 4 }}
+                      activeDot={{ r: 6 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -126,6 +126,13 @@ export async function getRecentDataPoints(
 }
 
 /**
+ * すべてのデータポイントを取得
+ */
+export async function getAllDataPoints(): Promise<DataPoint[]> {
+  return await db.dataPoints.toArray();
+}
+
+/**
  * すべてのデータポイントを削除（テスト用）
  */
 export async function clearAllDataPoints(): Promise<void> {

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,72 @@
+import { getAllMetrics } from './metrics';
+import { getAllDataPoints } from './data';
+
+/**
+ * メトリクスとデータポイントを JSON 形式でエクスポート
+ */
+export async function exportToJSON(): Promise<string> {
+  const [metrics, dataPoints] = await Promise.all([
+    getAllMetrics(),
+    getAllDataPoints()
+  ]);
+
+  const exportData = {
+    version: '1.0',
+    exportedAt: new Date().toISOString(),
+    metrics,
+    dataPoints
+  };
+
+  return JSON.stringify(exportData, null, 2);
+}
+
+/**
+ * メトリクスとデータポイントを CSV 形式でエクスポート
+ * 日付 × メトリクスのマトリクス形式
+ */
+export async function exportToCSV(): Promise<string> {
+  const [metrics, dataPoints] = await Promise.all([
+    getAllMetrics(),
+    getAllDataPoints()
+  ]);
+
+  // CSV ヘッダー
+  const metricNames = metrics.map(m => m.name);
+  const header = ['日付', ...metricNames].join(',');
+
+  // 日付ごとにデータをグループ化
+  const dateMap = new Map<string, Map<string, number>>();
+
+  dataPoints.forEach(dp => {
+    if (!dateMap.has(dp.date)) {
+      dateMap.set(dp.date, new Map());
+    }
+    dateMap.get(dp.date)!.set(dp.metricId, dp.value);
+  });
+
+  // CSV 行を生成
+  const rows = Array.from(dateMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, values]) => {
+      const row = [date];
+      metrics.forEach(metric => {
+        row.push(String(values.get(metric.id) ?? ''));
+      });
+      return row.join(',');
+    });
+
+  return [header, ...rows].join('\n');
+}
+
+/**
+ * ファイルをブラウザでダウンロード
+ */
+export function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,9 @@
         "name": "next"
       }
     ],
-    "paths": {}
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": [
     "next-env.d.ts",
@@ -32,6 +34,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "trees"
   ]
 }


### PR DESCRIPTION
## 概要

- Issue #9: Phase 4 - ダッシュボード UI の実装
- Issue #11: Phase 6 - データエクスポート機能の実装

このPRには2つのフェーズの実装が含まれています。

---

## Phase 4: ダッシュボード UI (#9)

### 実装内容

#### ダッシュボードページ (src/app/page.tsx)

- ✅ データ読み込み機能
  - `getAllMetrics()` でアクティブなメトリクスを取得
  - `getAllDataPoints()` で全データポイントを取得
  - Promise.all で並行読み込み

- ✅ グラフ表示
  - Recharts の LineChart コンポーネントを使用
  - メトリクスごとに独立したカード表示
  - メトリクスの color プロパティを使用

- ✅ データ変換ロジック
  - 日付でソート (昇順)
  - 日付フォーマット: YYYY-MM-DD → MM/DD
  - メトリクスごとにデータをフィルタリング

- ✅ UI/UX
  - ローディング状態の表示
  - メトリクスがない場合のメッセージ
  - データがない場合のメッセージ (グラフごと)
  - レスポンシブデザイン (モバイル・タブレット対応)
  - シャドウとカードレイアウト

#### グラフ機能

- X軸: 日付 (MM/DD形式)
- Y軸: 値 (メトリクスの min/max 設定を反映)
- グリッド線表示
- ツールチップ (ホバー時の詳細表示)
- 凡例表示
- データポイントのドット表示

### 受け入れ基準

- ✅ / ページでダッシュボードが表示される
- ✅ アクティブなメトリクスすべてのグラフが表示される
- ✅ 各グラフは独立したカードで表示
- ✅ 折れ線グラフが正しく描画される
- ✅ X軸: 日付、Y軸: 値
- ✅ グラフの色はメトリクス定義の color を使用
- ✅ データがない場合は適切なメッセージ表示
- ✅ モバイル・タブレットでレスポンシブ表示
- ✅ TypeScript ビルドエラーなし
- ✅ `pnpm build` 成功

---

## Phase 6: データエクスポート機能 (#11)

### 実装内容

#### 新規ファイル
- **src/lib/export.ts**: JSON/CSV エクスポート機能
  - `exportToJSON()`: メトリクスとデータポイントを JSON 形式でエクスポート
  - `exportToCSV()`: 日付 × メトリクスのマトリクス形式で CSV エクスポート
  - `downloadFile()`: ブラウザでファイルをダウンロード

#### 変更ファイル
- **src/lib/data.ts**: `getAllDataPoints()` 関数を追加
- **src/app/config/page.tsx**: エクスポート UI を実装
  - JSON エクスポートボタン
  - CSV エクスポートボタン
  - エラーハンドリング
  - ローディング状態管理
- **tsconfig.json**: パスエイリアス設定と trees ディレクトリ除外
- **.gitignore**: trees ディレクトリを追加

### 受け入れ基準

- ✅ JSON 形式でエクスポートできる
- ✅ CSV 形式でエクスポートできる
- ✅ ファイル名に日付が含まれる（YYYY-MM-DD）
- ✅ JSON にはメトリクス定義とデータポイントが含まれる
- ✅ CSV は日付 × メトリクスのマトリクス形式
- ✅ ダウンロードが正常に動作する
- ✅ TypeScript ビルドエラーなし
- ✅ `pnpm build` 成功

---

## テスト

- ✅ `pnpm build` でビルド成功確認

## 関連 Issue

- Closes #9
- Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)